### PR TITLE
Configure maxFiles option for logging for auto log files removal

### DIFF
--- a/src/config/default.config.js
+++ b/src/config/default.config.js
@@ -6,12 +6,13 @@ import path from 'path';
 
 export default {
   logging: {
+    maxFiles: 3,
     level: 'info',
     logDir: 'logs',
     jsonFormat: false,
     levelColumnWidth: 7,
-    tsFormat: () => new Date().toISOString(),
-    dateFormat: 'yyyy-MM-dd'
+    dateFormat: 'yyyy-MM-dd',
+    tsFormat: () => new Date().toISOString()
   },
   db: {
     client: 'sqlite3',

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -56,6 +56,7 @@ function createLogger(config) {
   const {
     level,
     logDir,
+    maxFiles,
     jsonFormat,
     dateFormat
   } = config;
@@ -70,10 +71,12 @@ function createLogger(config) {
         formatter: opts => customFormatter(opts, config)
       }),
       new winston.transports.DailyRotateFile({
+        maxFiles,
         align: true,
         level: level,
         prepend: true,
         json: jsonFormat,
+        zippedArchive: true,
         datePattern: dateFormat,
         filename: `${logDir}/-log.log`,
         formatter: opts => customFormatter(opts, config)


### PR DESCRIPTION
Old log files were not being removed right now. This will only keep limited log files (as per specified in maxFiles option).

**PS: Right now, I need to create two PRs in two repositories for exactly same thing (https://github.com/leapfrogtechnology/chill/pull/43), that's why we need this `chill-core` thing sooner.** :smile: